### PR TITLE
Update app to use translation placeholders

### DIFF
--- a/app.js
+++ b/app.js
@@ -1,4 +1,5 @@
 (function() {
+
   return {
     requests: {
         fetchUser: function () {

--- a/manifest.json
+++ b/manifest.json
@@ -10,6 +10,7 @@
   "location": "ticket_sidebar",
   "version": "1.0.1",
   "frameworkVersion": "1.0",
+  "defaultLanguage": "en",
   "parameters": [
   {
     "name": "endUserSpeed",

--- a/templates/show.hdbs
+++ b/templates/show.hdbs
@@ -1,2 +1,2 @@
-<h4>Yours <span class="muted">{{minReadRounded}} min read</span></h4>
-<h4>Previous <span class="muted">{{minReadRoundedAll}} min read</span></h4>
+<h4>{{t "yours"}} <span class="muted">{{minReadRounded}} min read</span></h4>
+<h4>{{t "previous"}} <span class="muted">{{minReadRoundedAll}} min read</span></h4>

--- a/translations/en.json
+++ b/translations/en.json
@@ -1,19 +1,20 @@
 {
   "app": {
-    "package": "app_name",
+    "package": "Minutes to Read",
     "description": {
-      "value": "Play the famous zen tunes in your help desk.",
+      "value": "This app tells you how long it will take the end-user to read your comment and estimates how long it will take for you to read the currentn comment thread.",
       "title": "app description"
-    },
-    "name": {
-      "value": "Buddha Machine",
-      "title": "app name"
     }
   },
 
-  "loading": {
-    "value": "Welcome to this Sample App",
-    "title": "loading placeholder"
+  "yours": {
+    "value": "Yours",
+    "title": "Yours"
+  },
+
+  "previous": {
+    "value": "Previous",
+    "title": "Previous"
   },
 
   "fetch": {


### PR DESCRIPTION
Pulling "Yours" & "Previous" strings out to instead use translation placeholders.
